### PR TITLE
bump travis build for deb packages to go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,8 @@ matrix:
 
     # This builder does the Ubuntu PPA upload
       os: linux
-      dist: trusty
-      go: 1.11.x
+      dist: xenial
+      go: 1.13.x
       env:
         - ubuntu-ppa
       git:

--- a/src/blockchain/smilobft/build/deb/smilo/deb.control
+++ b/src/blockchain/smilobft/build/deb/smilo/deb.control
@@ -2,7 +2,7 @@ Source: {{.Name}}
 Section: science
 Priority: extra
 Maintainer: {{.Author}}
-Build-Depends: debhelper (>= 8.0.0), golang-1.11
+Build-Depends: debhelper (>= 8.0.0), {{.GoBootPackage}}
 Standards-Version: 3.9.5
 Homepage: https://github.com/smilofoundation/go-smilo
 Vcs-Git: git://github.com/smilofoundation/go-smilo.git


### PR DESCRIPTION
update deb.control file to use correct Build-depends golang lib